### PR TITLE
Fix: Adjust layout of card slots in fishing tree

### DIFF
--- a/css/mini-games/fishing-tree.css
+++ b/css/mini-games/fishing-tree.css
@@ -17,8 +17,8 @@
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     grid-template-rows: repeat(2, 1fr);
-    gap: 20px; /* Adjusted gap to 20px as per new request */
-    padding: 10px 15px 20px 15px; /* Existing padding */
+    gap: 5px; /* Adjusted gap to 5px as per new request */
+    padding: 40px 15px 40px 15px; /* Existing padding */
     box-sizing: border-box;
     align-items: center; /* Aligns items vertically within their cell */
     justify-items: center; /* Aligns items horizontally within their cell */


### PR DESCRIPTION
- I reduced the gap between card slots from 20px to 5px.
- I moved the top card slots down by 30px and the bottom card slots up by 20px by adjusting the padding of the container.