### PR TITLE
Refactor rock reward display to show card face and add sound

### DIFF
--- a/css/mini-games/fishing-game.css
+++ b/css/mini-games/fishing-game.css
@@ -669,8 +669,9 @@
 /* New Local Fishing Reward Popup Styles */
 #fishing-reward-popup {
     /* Base styles are set inline in JS: display, position, transform, z-index, padding, background-color, border-radius, text-align, box-shadow, flex-direction, align-items */
-    border: 3px solid #5D9CEC; /* Example watery blue border */
+    border: 1px solid #5D9CEC; /* Watery blue border, thinned */
     background: linear-gradient(135deg, #4A90E2, #78B9F2); /* Example gradient */
+    padding: 5px !important; /* Override inline JS padding */
     /* flex-direction: column; /* This is already set inline */
     /* align-items: center; /* This is already set inline */
     cursor: pointer; /* To indicate it's clickable to dismiss */
@@ -678,7 +679,8 @@
 
 #fishing-reward-popup-img {
     /* Base styles are set inline in JS: max-width, max-height, border-radius, margin-bottom, border */
-    /* border: 2px solid #FFF; */ /* This is already set inline */
+    border: 1px solid #FFF !important; /* Override inline JS border */
+    margin-bottom: 5px !important; /* Override inline JS margin-bottom */
     object-fit: contain; /* Ensure the image content is not distorted */
 }
 

--- a/js/mini-games/fish-in-sea/rock-mechanics.js
+++ b/js/mini-games/fish-in-sea/rock-mechanics.js
@@ -246,12 +246,11 @@ function grantRockRewards(rockDef) {
         if (typeof window.fishingBasket !== 'undefined' && typeof window.fishingBasket.addCardToBasket === 'function') {
             window.fishingBasket.addCardToBasket(cardDataForBasket, 1);
 
-            if (typeof window.fishingUi !== 'undefined' && typeof window.fishingUi.showCatchPreview === 'function') {
-                const previewItem = {
-                    type: cardDataForBasket.type,
-                    details: cardDataForBasket
-                };
-                window.fishingUi.showCatchPreview(previewItem);
+            if (typeof window.fishingUi !== 'undefined' && typeof window.fishingUi.showCaughtItemDisplay === 'function') {
+                // Ensure cardDataForBasket has: imagePath, name, set, id (or cardId), rarityKey
+                // cardDataForBasket already prepared with these fields.
+                if (typeof playSound === 'function') playSound('sfx_reward_notification.mp3');
+                window.fishingUi.showCaughtItemDisplay(cardDataForBasket);
             }
         } else {
             console.warn("fishingBasket.addCardToBasket function not found. Item from rock not added to basket.");
@@ -278,8 +277,11 @@ function grantRockRewards(rockDef) {
             };
             // console.log(`[RockMechanics] Granted Summon Ticket: ${ticketDisplayName}, Type=${ticketDisplayData.type}, Source=${ticketDisplayData.source}`); // Aggressively removed
 
-            if (typeof window.fishingUi !== 'undefined' && typeof window.fishingUi.showCatchPreview === 'function') {
-                 window.fishingUi.showCatchPreview(ticketDisplayData);
+            if (typeof window.fishingUi !== 'undefined' && typeof window.fishingUi.showCaughtItemDisplay === 'function') {
+                 // Ensure ticketDisplayData has: imagePath, name, rarityKey (or type: 'ticket')
+                 // ticketDisplayData is prepared with imagePath, name, and type: 'ticket'.
+                 if (typeof playSound === 'function') playSound('sfx_reward_notification.mp3');
+                 window.fishingUi.showCaughtItemDisplay(ticketDisplayData);
             }
         } else {
             console.warn("summonTicketRarities array not defined/empty, or addSummonTickets function missing. Cannot grant random ticket from rock.");


### PR DESCRIPTION
This commit updates the display of card rewards obtained from rocks in the fishing mini-game.

Key changes:
- Modified `grantRockRewards` in `rock-mechanics.js` to use the `fishingUi.showCaughtItemDisplay` function, similar to bird rewards. This ensures the actual card face image is shown instead of a generic card back.
- Added an audio notification (`sfx_reward_notification.mp3`) that plays when a card or ticket is received from a rock.
- Adjusted the CSS for the `#fishing-reward-popup` and `#fishing-reward-popup-img` elements in `fishing-game.css` to reduce padding and border thickness. This makes the display area around the awarded item smaller, as per your requirements.

These changes improve your experience by providing clearer visual feedback for rock rewards and adding an auditory cue.