### PR TITLE
I've revamped the Exchange Shop UI and functionality for you.

### DIFF
--- a/css/mini-games/fishing-shop-modal.css
+++ b/css/mini-games/fishing-shop-modal.css
@@ -1,0 +1,134 @@
+/* Styling for the Fishing Exchange Shop Modal */
+
+/* Tabs */
+.fishing-shop-tabs {
+    display: flex;
+    flex-wrap: wrap; /* Allow tabs to wrap to the next line if they don't fit */
+    justify-content: center; /* Center tabs if they don't fill the width */
+    margin-bottom: 10px; /* Space below the tabs */
+}
+
+.fishing-shop-tabs .game-button {
+    margin: 5px; /* Spacing around each tab button */
+    padding: 8px 12px; /* Adjust padding as needed */
+    font-size: 0.9em; /* Slightly smaller font for more tabs */
+}
+
+/* Active tab styling - ensure this is distinct enough */
+.fishing-shop-tabs .game-button.active {
+    background-color: #007bff; /* Example active color, adjust to theme */
+    color: white;
+    border-color: #0056b3;
+    box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
+}
+
+/* Pagination Controls */
+#fishing-shop-pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 15px 0; /* Increased padding for better spacing */
+    border-top: 1px solid #eee; /* Optional: separator line */
+    margin-top: 10px; /* Space above pagination */
+}
+
+#fishing-shop-pagination button {
+    /* Assuming .game-button styles are available and suitable */
+    /* If not, replicate or create a smaller variant styling here */
+    margin: 0 8px; /* Spacing around pagination buttons */
+    padding: 6px 10px; /* Smaller padding for pagination buttons */
+    font-size: 0.85em;
+}
+
+#fishing-shop-pagination button:disabled,
+#fishing-shop-pagination button.disabled { /* Explicitly target .disabled class as well if used */
+    opacity: 0.5;
+    cursor: not-allowed;
+    background-color: #6c757d; /* Example disabled background */
+    border-color: #545b62;
+}
+
+#fishing-shop-pagination .pagination-info { /* Style for "Page X of Y" text */
+    margin: 0 12px;
+    font-size: 0.9em;
+    color: #333; /* Adjust color as per theme */
+}
+
+/* Card Grid - Relies on existing .fishing-basket-grid and .gallery-grid */
+/* Ensure parent .fishing-game-modal-scrollable-content handles scrolling. */
+/* #fishing-shop-items-grid specific adjustments if needed: */
+#fishing-shop-items-grid {
+    /* The grid itself should not scroll, its parent does. */
+    /* It uses gallery-grid for layout, which should be responsive. */
+    /* min-height can be useful to maintain a certain size before items are loaded */
+    min-height: 150px; /* Example: Ensures the area doesn't collapse when empty */
+}
+
+
+/* Modal Content Area */
+/* .fishing-game-modal-content or .fishing-shop-modal-content */
+.fishing-shop-modal-content {
+    /* max-height is often controlled by .fishing-game-modal-content */
+    /* but ensure the overall structure allows for this. */
+    /* The .fishing-game-modal-scrollable-content inside it is key */
+}
+
+.fishing-game-modal-scrollable-content {
+    /* This class is used in the shop modal HTML for the item grid's container */
+    /* Ensure it has appropriate max-height and overflow */
+    /* These styles might already exist in modals.css or components.css */
+    max-height: 400px; /* Example max-height, adjust as needed */
+    overflow-y: auto;
+    padding-right: 5px; /* For scrollbar spacing */
+}
+
+/* Specific styling for the ticket balances area if needed */
+.fishing-shop-ticket-balances-area {
+    padding: 10px;
+    text-align: center;
+    border-bottom: 1px solid #eee; /* Separator line */
+    margin-bottom: 10px;
+    font-size: 0.95em;
+}
+.fishing-shop-ticket-balances-area .rarity-text-common,
+.fishing-shop-ticket-balances-area .rarity-text-uncommon,
+.fishing-shop-ticket-balances-area .rarity-text-rare,
+.fishing-shop-ticket-balances-area .rarity-text-epic,
+.fishing-shop-ticket-balances-area .rarity-text-legendary,
+.fishing-shop-ticket-balances-area .rarity-text-mythic,
+.fishing-shop-ticket-balances-area .rarity-text-divine {
+    margin: 0 5px; /* Spacing between different ticket counts */
+    font-weight: bold;
+}
+
+/* Ensure item names and details within cards in the shop are readable */
+#fishing-shop-items-grid .basket-card-item .basket-card-name {
+    font-size: 0.8em; /* Adjust if too small/large */
+}
+#fishing-shop-items-grid .basket-card-item .basket-card-quantity,
+#fishing-shop-items-grid .basket-card-item .basket-card-rarity,
+#fishing-shop-items-grid .basket-card-item .basket-card-grade {
+    font-size: 0.75em; /* Adjust if too small/large */
+}
+
+/* Responsive adjustments for smaller screens if necessary */
+@media (max-width: 600px) {
+    .fishing-shop-tabs .game-button {
+        padding: 6px 8px;
+        font-size: 0.8em;
+    }
+
+    #fishing-shop-pagination button {
+        padding: 5px 8px;
+        font-size: 0.8em;
+    }
+
+    #fishing-shop-pagination .pagination-info {
+        margin: 0 8px;
+        font-size: 0.85em;
+    }
+
+    .fishing-game-modal-scrollable-content {
+        max-height: 300px; /* Adjust for smaller screens */
+    }
+}

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="css/components/global-item-display.css">
   <link rel="stylesheet" href="css/mini-games/fishing-sky.css">
   <link rel="stylesheet" href="css/mini-games/fishing-basket.css">
+  <link rel="stylesheet" href="css/mini-games/fishing-shop-modal.css">
   <link rel="stylesheet" href="css/mini-games/summongame.css">
 </head>
 <body>

--- a/js/mini-games/fish-in-sea/ui/fishing-ui.js
+++ b/js/mini-games/fish-in-sea/ui/fishing-ui.js
@@ -346,21 +346,23 @@ const fishingUi = {
              <div id="fishing-shop-modal" class="fishing-game-modal-overlay" style="display: none;">
                 <div class="fishing-game-modal-content fishing-shop-modal-content">
                     <div class="fishing-game-modal-header">
-                        <h3>Fishing Exchange</h3>
+                        <h3>Exchange Shop</h3>
                         <button id="fishing-shop-close-btn" class="game-button">&times;</button>
                     </div>
                     <div id="fishing-shop-ticket-balances" class="fishing-shop-ticket-balances-area"></div>
                     <div class="fishing-shop-tabs">
-                        <button class="game-button active" data-tab-type="fish">Fish/Cards</button>
-                        <button class="game-button" data-tab-type="fruit">Fruit</button>
-                        <button class="game-button" data-tab-type="minerals">Minerals</button>
+                        <button class="game-button active" data-tab-type="all">All</button>
+                        <button class="game-button" data-tab-type="fish_card">Fish</button>
+                        <button class="game-button" data-tab-type="fruit_card">Fruit</button>
+                        <button class="game-button" data-tab-type="mineral_card">Rock</button>
+                        <button class="game-button" data-tab-type="bird_reward_card">Bird</button>
                     </div>
                     <div class="fishing-game-modal-scrollable-content">
-                        <div id="fishing-shop-exchange-info" class="fishing-shop-exchange-info-area"></div>
-                        <div id="fishing-shop-items-grid" class="fishing-shop-items-grid-area"></div>
+                        <div id="fishing-shop-items-grid" class="fishing-basket-grid gallery-grid"></div>
+                        <div id="fishing-shop-pagination" class="pagination-controls"></div>
                     </div>
                     <div class="fishing-game-modal-actions">
-                        <button id="fishing-shop-sell-all-btn" class="game-button game-button-variant">Exchange All in Tab</button>
+                        <button id="fishing-shop-sell-all-btn" class="game-button game-button-variant">Exchange All Eligible in Tab</button>
                     </div>
                 </div>
             </div>
@@ -506,7 +508,7 @@ const fishingUi = {
                 tab.addEventListener('click', () => {
                     ui.shopTabs.forEach(t => t.classList.remove('active'));
                     tab.classList.add('active');
-                    renderFishingShopItems(tab.dataset.tabType);
+                    renderFishingShopItems(tab.dataset.tabType, 1);
                     playSound('sfx_button_click_subtle.mp3');
                 });
             });


### PR DESCRIPTION
This implements a new UI for the Exchange Shop within the Fish in Sea mini-game. The shop now displays items directly from your fishing basket, organized into tabs: All, Fish, Fruit, Rock, and Bird.

Here are the key changes:
- I modified `fishing-ui.js` to update the HTML structure of the shop modal, adding new tabs and a pagination area.
- I updated `fishing-shop-modal.js` to:
    - Render cards from the fishing basket in the selected tab.
    - Filter items based on `cardData.type` (fish_card, fruit_card, etc.) and `isLocked` status.
    - Implement pagination, displaying a maximum of 64 cards per page.
    - Add pagination controls (Previous, Next, Page X of Y).
    - The 'All' tab displays all eligible unlocked items from other categories.
    - The 'Exchange All Eligible in Tab' button works for specific category tabs but is disabled for the 'All' tab.
- I added new CSS (`css/mini-games/fishing-shop-modal.css`) for styling the updated shop tabs, pagination controls, and ensuring overall visual consistency with other modals. Card display reuses existing styles from the fishing basket/gallery.

The "Exchange Progress" text has been removed in favor of displaying the actual cards available for exchange. Ticket balances are still displayed. Cards in the shop grid are display-only; interaction for exchange is handled by the "Exchange All Eligible in Tab" button.