### PR TITLE
I've made some style updates to display exchange rates inline in the …

### DIFF
--- a/css/mini-games/fishing-shop-modal.css
+++ b/css/mini-games/fishing-shop-modal.css
@@ -187,12 +187,16 @@
     font-size: 0.9em;
     max-height: 150px; /* Max height for this area if many rules exist */
     overflow-y: auto;   /* Scroll if content exceeds max-height */
+    text-align: left; /* Ensure items align to the left if container was centered */
 }
 
 /* Styling for each line of exchange progress */
 .fishing-shop-current-tab-exchange-info-area .exchange-progress-entry {
-    margin: 5px 0;
+    display: inline-block; /* Allow items to sit side-by-side */
+    margin: 5px 0; /* Vertical margin */
+    margin-right: 15px; /* Horizontal margin for spacing between items */
     color: #333;
+    vertical-align: top; /* Align items from their top edge */
 }
 
 .fishing-shop-current-tab-exchange-info-area .exchange-progress-entry strong {


### PR DESCRIPTION
…Exchange Shop.

Specifically, I updated the CSS for the Exchange Shop's tab-specific exchange progress area. This will allow individual exchange rate entries (e.g., "Common Fish for Common Ticket: X/Y") to appear side-by-side on the same line.

Here's a summary of the changes:
- I modified `css/mini-games/fishing-shop-modal.css`:
    - I changed `.exchange-progress-entry` to `display: inline-block;`.
    - I added `margin-right` for horizontal spacing between entries.
    - I set `vertical-align: top;` for consistent alignment of entries.
    - I ensured the parent container (`.fishing-shop-current-tab-exchange-info-area`) is set to `text-align: left;` for proper flow of inline-block elements.

As a result, exchange rates will now appear more compactly, using available horizontal space before wrapping to the next line. The existing vertical scrollability of the progress area is maintained for cases with many exchange rules.